### PR TITLE
Exposing MountPath build variable for use by Ansible provisioner

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -64,6 +64,12 @@ const (
 	Delete   ResolvConfBehavior = "delete"
 )
 
+const ChrootKey = "mount_path"
+
+var generatedDataKeys = map[string]string{
+	ChrootKey: "MountPath",
+}
+
 type Builder struct {
 	config Config
 	runner *multistep.BasicRunner
@@ -215,7 +221,13 @@ func (b *Builder) Prepare(cfgs ...interface{}) ([]string, []string, error) {
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warnings, errs
 	}
-	return nil, warnings, nil
+
+	generatedData := make([]string, 0, len(generatedDataKeys))
+	for _, v := range generatedDataKeys {
+		generatedData = append(generatedData, v)
+	}
+
+	return generatedData, warnings, nil
 }
 
 type wrappedCommandTemplate struct {
@@ -270,9 +282,14 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			&stepResizeFs{PartitionsKey: "partitions"},
 		)
 	}
-	const ChrootKey = "mount_path"
+
 	steps = append(steps,
-		&stepMountImage{PartitionsKey: "partitions", ResultKey: ChrootKey, MountPath: b.config.MountPath},
+		&stepMountImage{
+			PartitionsKey:    "partitions",
+			ResultKey:        ChrootKey,
+			MountPath:        b.config.MountPath,
+			GeneratedDataKey: generatedDataKeys[ChrootKey],
+		},
 		&chroot.StepMountExtra{
 			ChrootMounts: b.config.ChrootMounts,
 		},
@@ -311,11 +328,15 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		return nil, errors.New("step canceled or halted")
 	}
 
-	return &Artifact{image: state.Get("imagefile").(string)}, nil
+	return &Artifact{
+		image:     state.Get("imagefile").(string),
+		StateData: map[string]interface{}{"generated_data": state.Get("generated_data")},
+	}, nil
 }
 
 type Artifact struct {
-	image string
+	image     string
+	StateData map[string]interface{}
 }
 
 func (a *Artifact) BuilderId() string {
@@ -335,7 +356,7 @@ func (a *Artifact) String() string {
 }
 
 func (a *Artifact) State(name string) interface{} {
-	return nil
+	return a.StateData[name]
 }
 
 func (a *Artifact) Destroy() error {

--- a/pkg/builder/step_mount_image.go
+++ b/pkg/builder/step_mount_image.go
@@ -14,10 +14,11 @@ import (
 )
 
 type stepMountImage struct {
-	PartitionsKey string
-	ResultKey     string
-	MountPath     string
-	mountpoints   []string
+	PartitionsKey    string
+	ResultKey        string
+	MountPath        string
+	GeneratedDataKey string
+	mountpoints      []string
 }
 
 func (s *stepMountImage) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -80,6 +81,9 @@ func (s *stepMountImage) Run(ctx context.Context, state multistep.StateBag) mult
 	}
 
 	state.Put(s.ResultKey, s.MountPath)
+
+	updateGeneratedData(state, s.GeneratedDataKey, s.MountPath)
+
 	return multistep.ActionContinue
 }
 
@@ -107,4 +111,14 @@ func reverse(numbers []string) []string {
 		newNumbers[i], newNumbers[j] = numbers[j], numbers[i]
 	}
 	return newNumbers
+}
+
+func updateGeneratedData(state multistep.StateBag, key string, value string) {
+	generatedData, found := state.GetOk("generated_data")
+
+	if found {
+		generatedData.(map[string]interface{})[key] = value
+	} else {
+		state.Put("generated_data", map[string]interface{}{key: value})
+	}
 }

--- a/samples/raspbian_ansible_chroot.pkr.hcl
+++ b/samples/raspbian_ansible_chroot.pkr.hcl
@@ -1,0 +1,24 @@
+source "arm-image" "raspberry_pi_os" {
+  iso_checksum = "008d7377b8c8b853a6663448a3f7688ba98e2805949127a1d9e8859ff96ee1a9"
+  iso_url      = "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip"
+}
+
+build {
+  sources = ["source.arm-image.raspberry_pi_os"]
+
+  provisioner "ansible" {
+    playbook_file    = "/vagrant/samples/raspbian_ansible_chroot.yml"
+    ansible_env_vars = [
+      "ANSIBLE_FORCE_COLOR=1",
+      "PYTHONUNBUFFERED=1",
+    ]
+    extra_arguments  = [
+      # The following arguments are required for running Ansible within a chroot
+      # See https://www.packer.io/plugins/provisioners/ansible/ansible#chroot-communicator for details
+      "--connection=chroot",
+      "--become-user=root",
+      #  Ansible needs this to find the mount path
+      "-e ansible_host=${build.MountPath}"
+    ]
+  }
+}


### PR DESCRIPTION
This addresses the issue described here: https://github.com/solo-io/packer-plugin-arm-image/issues/121

As per the suggested solution, the variable `build.MountPath` can now be accessed from within a provisioner.

This allows the use of Packer's built-in Ansible provisioner, which removes the need to manually invoke Ansible using `shell-local` as per [/samples/raspbian_ansible_chroot.json](https://github.com/solo-io/packer-plugin-arm-image/blob/master/samples/raspbian_ansible_chroot.json)

I've included a new sample, which is essentially a rewrite of [/samples/raspbian_ansible_chroot.json](https://github.com/solo-io/packer-plugin-arm-image/blob/master/samples/raspbian_ansible_chroot.json) but now using the Ansible provisioner (and written in HCL2).

I don't know Go very well, so I can make changes as needed.  I've done some basic manual testing on my machine, and everything seems to work!

Thanks.
