### PR TITLE
Update Vagrantfile to support hyperv

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "generic/ubuntu2004"
   config.vm.synced_folder "./", "/vagrant", disabled: false
   config.vm.provision "build-env", type: "shell", :path => "provision-build-env.sh", privileged: false
   config.vm.provision "packer-plugin-arm-image", type: "shell", :path => "provision-packer-plugin-arm-image.sh", privileged: false, env: {"GIT_CLONE_URL" => ENV["GIT_CLONE_URL"]}


### PR DESCRIPTION
This updates the vagrantfile to use this box, which is the same as focal64, but supported by more platforms (e.g. HyperV) https://app.vagrantup.com/generic/boxes/ubuntu2004