### PR TITLE
Add image_arch and qemu_required options

### DIFF
--- a/docs-partials/pkg/builder/Config-not-required.mdx
+++ b/docs-partials/pkg/builder/Config-not-required.mdx
@@ -12,6 +12,10 @@
   If not provided, we will try to deduce it from the image url. (see autoDetectType())
   For list of valid values, see: pkg/image/utils/images.go
 
+- `image_arch` (arch.KnownArchType) - Image's target CPU architecture.
+  This is used to determine if qemu is necessary and which flavor to use.
+  Defaults to "arm". For list of valid values, see: pkg/image/arch/arch.go
+
 - `image_mounts` ([]string) - Where to mounts the image partitions in the chroot.
   first entry is the mount point of the first partition. etc..
 
@@ -37,12 +41,15 @@
   fill up this much room. I.e. if the generated image is 256MB and TargetImageSize
   is set to 384MB the last partition will be extended with an additional 128MB.
 
-- `qemu_binary` (string) - Qemu binary to use. default is qemu-arm-static
+- `qemu_binary` (string) - Qemu binary to use. default is determined based on `image_arch`.
   If this is an absolute path, it will be used. Otherwise, we will look for one in your PATH
   and finally, try to auto fetch one from https://github.com/multiarch/qemu-user-static/
 
 - `disable_embedded` (bool) - Do not use embedded qemu.
 
 - `qemu_args` ([]string) - Arguments to qemu binary. default depends on the image type. see init() function above.
+
+- `qemu_required` (bool) - Use qemu even when the build machine's CPU architecture matches the image's CPU architecture.
+  Defaults to true if non-default `qemu_binary` or `qemu_args` are supplied.
 
 <!-- End of code generated from the comments of the Config struct in pkg/builder/config.go; -->

--- a/pkg/builder/config.go
+++ b/pkg/builder/config.go
@@ -7,6 +7,7 @@ import (
 	packer_common_common "github.com/hashicorp/packer-plugin-sdk/common"
 	packer_common_commonsteps "github.com/hashicorp/packer-plugin-sdk/multistep/commonsteps"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+	"github.com/solo-io/packer-plugin-arm-image/pkg/image/arch"
 	"github.com/solo-io/packer-plugin-arm-image/pkg/image/utils"
 )
 
@@ -31,6 +32,11 @@ type Config struct {
 	// If not provided, we will try to deduce it from the image url. (see autoDetectType())
 	// For list of valid values, see: pkg/image/utils/images.go
 	ImageType utils.KnownImageType `mapstructure:"image_type"`
+
+	// Image's target CPU architecture.
+	// This is used to determine if qemu is necessary and which flavor to use.
+	// Defaults to "arm". For list of valid values, see: pkg/image/arch/arch.go
+	ImageArch arch.KnownArchType `mapstructure:"image_arch"`
 
 	// Where to mounts the image partitions in the chroot.
 	// first entry is the mount point of the first partition. etc..
@@ -63,7 +69,7 @@ type Config struct {
 	// is set to 384MB the last partition will be extended with an additional 128MB.
 	TargetImageSize uint64 `mapstructure:"target_image_size"`
 
-	// Qemu binary to use. default is qemu-arm-static
+	// Qemu binary to use. default is determined based on `image_arch`.
 	// If this is an absolute path, it will be used. Otherwise, we will look for one in your PATH
 	// and finally, try to auto fetch one from https://github.com/multiarch/qemu-user-static/
 	QemuBinary string `mapstructure:"qemu_binary"`
@@ -71,6 +77,9 @@ type Config struct {
 	DisableEmbedded bool `mapstructure:"disable_embedded"`
 	// Arguments to qemu binary. default depends on the image type. see init() function above.
 	QemuArgs []string `mapstructure:"qemu_args"`
+	// Use qemu even when the build machine's CPU architecture matches the image's CPU architecture.
+	// Defaults to true if non-default `qemu_binary` or `qemu_args` are supplied.
+	QemuRequired bool `mapstructure:"qemu_required"`
 
 	ctx interpolate.Context
 }

--- a/pkg/builder/config.hcl2spec.go
+++ b/pkg/builder/config.hcl2spec.go
@@ -4,6 +4,7 @@ package builder
 
 import (
 	"github.com/hashicorp/hcl/v2/hcldec"
+	"github.com/solo-io/packer-plugin-arm-image/pkg/image/arch"
 	"github.com/solo-io/packer-plugin-arm-image/pkg/image/utils"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -28,6 +29,7 @@ type FlatConfig struct {
 	OutputDir              *string               `mapstructure:"output_directory" cty:"output_directory" hcl:"output_directory"`
 	OutputFile             *string               `mapstructure:"output_filename" cty:"output_filename" hcl:"output_filename"`
 	ImageType              *utils.KnownImageType `mapstructure:"image_type" cty:"image_type" hcl:"image_type"`
+	ImageArch              *arch.KnownArchType   `mapstructure:"image_arch" cty:"image_arch" hcl:"image_arch"`
 	ImageMounts            []string              `mapstructure:"image_mounts" cty:"image_mounts" hcl:"image_mounts"`
 	MountPath              *string               `mapstructure:"mount_path" cty:"mount_path" hcl:"mount_path"`
 	ChrootMounts           [][]string            `mapstructure:"chroot_mounts" cty:"chroot_mounts" hcl:"chroot_mounts"`
@@ -38,6 +40,7 @@ type FlatConfig struct {
 	QemuBinary             *string               `mapstructure:"qemu_binary" cty:"qemu_binary" hcl:"qemu_binary"`
 	DisableEmbedded        *bool                 `mapstructure:"disable_embedded" cty:"disable_embedded" hcl:"disable_embedded"`
 	QemuArgs               []string              `mapstructure:"qemu_args" cty:"qemu_args" hcl:"qemu_args"`
+	QemuRequired           *bool                 `mapstructure:"qemu_required" cty:"qemu_required" hcl:"qemu_required"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -69,6 +72,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"output_directory":           &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
 		"output_filename":            &hcldec.AttrSpec{Name: "output_filename", Type: cty.String, Required: false},
 		"image_type":                 &hcldec.AttrSpec{Name: "image_type", Type: cty.String, Required: false},
+		"image_arch":                 &hcldec.AttrSpec{Name: "image_arch", Type: cty.String, Required: false},
 		"image_mounts":               &hcldec.AttrSpec{Name: "image_mounts", Type: cty.List(cty.String), Required: false},
 		"mount_path":                 &hcldec.AttrSpec{Name: "mount_path", Type: cty.String, Required: false},
 		"chroot_mounts":              &hcldec.AttrSpec{Name: "chroot_mounts", Type: cty.List(cty.List(cty.String)), Required: false},
@@ -79,6 +83,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"qemu_binary":                &hcldec.AttrSpec{Name: "qemu_binary", Type: cty.String, Required: false},
 		"disable_embedded":           &hcldec.AttrSpec{Name: "disable_embedded", Type: cty.Bool, Required: false},
 		"qemu_args":                  &hcldec.AttrSpec{Name: "qemu_args", Type: cty.List(cty.String), Required: false},
+		"qemu_required":              &hcldec.AttrSpec{Name: "qemu_required", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/pkg/image/arch/arch.go
+++ b/pkg/image/arch/arch.go
@@ -1,0 +1,39 @@
+package arch
+
+import (
+	"runtime"
+)
+
+type KnownArchType string
+
+const (
+	Unknown KnownArchType = ""
+	Arm     KnownArchType = "arm"
+	ArmBE   KnownArchType = "armbe"
+	Arm64   KnownArchType = "arm64"
+	Arm64BE KnownArchType = "arm64be"
+)
+
+var knownValues = map[KnownArchType]string{
+	Arm:     string(Arm),
+	ArmBE:   string(ArmBE),
+	Arm64:   string(Arm64),
+	Arm64BE: string(Arm64BE),
+}
+
+func Values() []string {
+	var values []string
+	for _, value := range knownValues {
+		values = append(values, value)
+	}
+	return values
+}
+
+func (arch KnownArchType) Valid() bool {
+	_, ok := knownValues[arch]
+	return ok
+}
+
+func (arch KnownArchType) IsNative() bool {
+	return string(arch) == runtime.GOARCH
+}

--- a/samples/pi-ubuntu-core-secure-zfs-nodeexporter.json
+++ b/samples/pi-ubuntu-core-secure-zfs-nodeexporter.json
@@ -6,7 +6,7 @@
   "builders": [{
     "type": "arm-image",
     "image_type": "raspberrypi",
-    "qemu_binary": "qemu-aarch64-static",
+    "image_arch": "arm64",
     "iso_url" : "http://cdimage.ubuntu.com/releases/20.04/release/ubuntu-20.04-preinstalled-server-arm64+raspi.img.xz",
     "iso_checksum":"sha256:48167067d65c5192ffe041c9cc4958cb7fcdfd74fa15e1937a47430ed7b9de99",
     "last_partition_extra_size" : "1073741824",
@@ -19,7 +19,7 @@
         ["binfmt_misc", "binfmt_misc", "/proc/sys/fs/binfmt_misc"],
         ["bind", "/run/resolvconf", "/run/resolvconf"]
     ]
-  }],  
+  }],
   "provisioners": [
     {
       "type": "shell",


### PR DESCRIPTION
The inclusion of image_arch improves detecting when qemu is required (#145).
The image architecture is also used to intelligently determine which flavor
of qemu is required, if any.
Additionally, the qemu_required option had been added which forces the use
of qemu even when it's not stricly required by qemu_args, qemu_binary, or
image_arch.  This aims to help in build situations where the user wants
reproducible emulation or when QEMU_* environment variables need to be respected.
The default values for both of these options have been chosen to prevent
any breaking changes to existing configurations.
One example configuration has been updated to enable native image building
should the build environment support it.