### PR TITLE
Improve timeout behavior

### DIFF
--- a/pkg/builder/step_map_image.go
+++ b/pkg/builder/step_map_image.go
@@ -48,7 +48,6 @@ func (s *stepMapImage) Run(_ context.Context, state multistep.StateBag) multiste
 	loop := strings.Split(path, "/")[2]
 	prefix := loop + "p"
 
-	time.Sleep(2 * time.Second)
 	// Look for all partitions of created loopback
 	var partitions []string
 	cPartitions := make(chan []string)
@@ -95,7 +94,7 @@ func (s *stepMapImage) Run(_ context.Context, state multistep.StateBag) multiste
 			n_j, _ := strconv.Atoi(partitions[j][len(partPrefix):])
 			return n_i < n_j
 		})
-	case <-time.After(time.Second):
+	case <-time.After(60*time.Second):
 		cancel()
 	}
 


### PR DESCRIPTION
Instead of putting one timeout of 2 sec at the beginning of the check for the loop devices, use the already existing timeout implementation inside the loop and just increase the maximum timeout to 60 sec. This improves the overall behavior, because as soon as the loop devices are detected, the loop will be exited, but it also increases the maximum possible time to wait for the loop devices. This is helpful when being used on slower systems.