### PR TITLE
Re-add sleep of 2 sec before looking for partitions

### DIFF
--- a/pkg/builder/step_map_image.go
+++ b/pkg/builder/step_map_image.go
@@ -48,6 +48,7 @@ func (s *stepMapImage) Run(_ context.Context, state multistep.StateBag) multiste
 	loop := strings.Split(path, "/")[2]
 	prefix := loop + "p"
 
+	time.Sleep(2 * time.Second)
 	// Look for all partitions of created loopback
 	var partitions []string
 	cPartitions := make(chan []string)


### PR DESCRIPTION
This fixes issue #162 and #165. I refactored the timeout handling, with #169 by increasing the existing timeout and removing the additional 2 sec sleep, because the 2 sec sleep was not working in all cases. Unfortunately, the increase alone is not sufficient, so I'm re-adding the 2 sec sleep again.